### PR TITLE
chore(claude): remove ntfy notification and permission hooks

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,32 +1,10 @@
 {
-  "hooks": {
-    "Notification": [
-      {
-        "matcher": "permission_prompt|idle_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/ntfy-notify.sh"
-          }
-        ]
-      }
-    ],
-    "PermissionRequest": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/claude-push.sh"
-          }
-        ]
-      }
-    ]
-  },
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
     "ui-ux-pro-max@ui-ux-pro-max-skill": true,
-    "discord@claude-plugins-official": true
+    "discord@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "ui-ux-pro-max-skill": {
@@ -35,5 +13,7 @@
         "repo": "nextlevelbuilder/ui-ux-pro-max-skill"
       }
     }
-  }
+  },
+  "remoteControlAtStartup": true,
+  "agentPushNotifEnabled": true
 }


### PR DESCRIPTION
## Summary

- Remove the `Notification` and `PermissionRequest` hooks from `claude/settings.json` that invoked `~/.claude/hooks/ntfy-notify.sh` and `~/.claude/hooks/claude-push.sh`. The official Claude app now provides equivalent push notifications via `agentPushNotifEnabled`, making the custom ntfy-based hooks redundant.
- The shell scripts under `claude/hooks/` are intentionally kept in the repo for future reference.
- Also includes settings persisted by recent Claude Code sessions: `security-guidance` plugin, `remoteControlAtStartup`, and `agentPushNotifEnabled`.

## Test plan

- [ ] After this lands, start a new Claude Code session and trigger a permission prompt; confirm no ntfy push notifications are sent, and that the official Claude app receives the notification instead.
- [ ] `jq '.hooks' ~/.claude/settings.json` returns `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)